### PR TITLE
chore: add Actions failure notifications

### DIFF
--- a/.github/workflows/notify-failure.yml
+++ b/.github/workflows/notify-failure.yml
@@ -1,0 +1,156 @@
+name: Notify Workflow Failure
+
+on:
+  workflow_call:
+    inputs:
+      status:
+        required: true
+        type: string
+      repo:
+        required: true
+        type: string
+      workflow:
+        required: true
+        type: string
+      job:
+        required: true
+        type: string
+      branch:
+        required: true
+        type: string
+      sha:
+        required: true
+        type: string
+      actor:
+        required: true
+        type: string
+      event_name:
+        required: true
+        type: string
+      run_number:
+        required: true
+        type: string
+      run_url:
+        required: true
+        type: string
+    secrets:
+      SLACK_WEBHOOK_URL:
+        required: false
+      TELEGRAM_BOT_TOKEN:
+        required: false
+      TELEGRAM_CHAT_ID:
+        required: false
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    if: ${{ inputs.status == 'failure' }}
+    env:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+      TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+    steps:
+      - name: Send Slack notification
+        if: ${{ env.SLACK_WEBHOOK_URL != '' }}
+        env:
+          REPO: ${{ inputs.repo }}
+          WORKFLOW: ${{ inputs.workflow }}
+          JOB: ${{ inputs.job }}
+          BRANCH: ${{ inputs.branch }}
+          COMMIT_SHA: ${{ inputs.sha }}
+          ACTOR: ${{ inputs.actor }}
+          EVENT_NAME: ${{ inputs.event_name }}
+          RUN_NUMBER: ${{ inputs.run_number }}
+          RUN_URL: ${{ inputs.run_url }}
+        run: |
+          short_sha="${COMMIT_SHA:0:7}"
+          payload="$(jq -n \
+            --arg repo "$REPO" \
+            --arg workflow "$WORKFLOW" \
+            --arg job "$JOB" \
+            --arg branch "$BRANCH" \
+            --arg sha "$short_sha" \
+            --arg actor "$ACTOR" \
+            --arg event_name "$EVENT_NAME" \
+            --arg run_number "$RUN_NUMBER" \
+            --arg run_url "$RUN_URL" \
+            '{
+              text: ("GitHub Actions failure: " + $repo),
+              blocks: [
+                {
+                  type: "section",
+                  text: {
+                    type: "mrkdwn",
+                    text: ("*GitHub Actions failed*\n*Repo:* " + $repo + "\n*Workflow:* " + $workflow + "\n*Job:* " + $job + "\n*Branch/ref:* " + $branch + "\n*Commit:* `" + $sha + "`\n*Actor:* " + $actor + "\n*Event:* " + $event_name + "\n*Run:* #" + $run_number + "\n<" + $run_url + "|Open failed run>")
+                  }
+                }
+              ]
+            }')"
+
+          curl -fsS -X POST \
+            -H "Content-Type: application/json" \
+            --data "$payload" \
+            "$SLACK_WEBHOOK_URL"
+
+      - name: Skip Slack notification
+        if: ${{ env.SLACK_WEBHOOK_URL == '' }}
+        run: echo "SLACK_WEBHOOK_URL is not set; skipping Slack notification."
+
+      - name: Send Telegram notification
+        if: ${{ env.TELEGRAM_BOT_TOKEN != '' && env.TELEGRAM_CHAT_ID != '' }}
+        env:
+          REPO: ${{ inputs.repo }}
+          WORKFLOW: ${{ inputs.workflow }}
+          JOB: ${{ inputs.job }}
+          BRANCH: ${{ inputs.branch }}
+          COMMIT_SHA: ${{ inputs.sha }}
+          ACTOR: ${{ inputs.actor }}
+          EVENT_NAME: ${{ inputs.event_name }}
+          RUN_NUMBER: ${{ inputs.run_number }}
+          RUN_URL: ${{ inputs.run_url }}
+        run: |
+          short_sha="${COMMIT_SHA:0:7}"
+          message="$(jq -n -r \
+            --arg repo "$REPO" \
+            --arg workflow "$WORKFLOW" \
+            --arg job "$JOB" \
+            --arg branch "$BRANCH" \
+            --arg sha "$short_sha" \
+            --arg actor "$ACTOR" \
+            --arg event_name "$EVENT_NAME" \
+            --arg run_number "$RUN_NUMBER" \
+            --arg run_url "$RUN_URL" \
+            '
+            def field($label; $value):
+              "<b>" + $label + ":</b> <code>" + ($value | @html) + "</code>";
+
+            "<b>GitHub Actions failed</b>\n\n" +
+            field("Repo"; $repo) + "\n" +
+            field("Workflow"; $workflow) + "\n" +
+            field("Job"; $job) + "\n" +
+            field("Branch/ref"; $branch) + "\n" +
+            field("Commit"; $sha) + "\n" +
+            field("Actor"; $actor) + "\n" +
+            field("Event"; $event_name) + "\n" +
+            field("Run"; "#" + $run_number) + "\n\n" +
+            "<a href=\"" + ($run_url | @html) + "\">Open failed run</a>"
+            ')"
+
+          payload="$(jq -n \
+            --arg chat_id "$TELEGRAM_CHAT_ID" \
+            --arg text "$message" \
+            '{
+              chat_id: $chat_id,
+              text: $text,
+              parse_mode: "HTML",
+              disable_web_page_preview: true
+            }')"
+
+          curl -fsS -X POST \
+            -H "Content-Type: application/json" \
+            --data "$payload" \
+            "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage"
+
+      - name: Skip Telegram notification
+        if: ${{ env.TELEGRAM_BOT_TOKEN == '' || env.TELEGRAM_CHAT_ID == '' }}
+        run: echo "TELEGRAM_BOT_TOKEN or TELEGRAM_CHAT_ID is not set; skipping Telegram notification."

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -41,3 +41,24 @@ jobs:
             playwright-report/
             test-results/
           retention-days: 7
+
+  notify-failure:
+    name: Notify failure
+    needs: [test]
+    if: ${{ always() && needs.test.result == 'failure' }}
+    uses: ./.github/workflows/notify-failure.yml
+    with:
+      status: failure
+      repo: ${{ github.repository }}
+      workflow: ${{ github.workflow }}
+      job: Playwright matrix
+      branch: ${{ github.ref_name }}
+      sha: ${{ github.sha }}
+      actor: ${{ github.actor }}
+      event_name: ${{ github.event_name }}
+      run_number: ${{ github.run_number }}
+      run_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+    secrets:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+      TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}

--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@ Run the dev server:
 npm run dev
 ```
 
+## CI Notifications
+
+GitHub Actions failure notifications are documented in
+[`docs/ACTIONS_NOTIFICATIONS.md`](docs/ACTIONS_NOTIFICATIONS.md).
+
 ## Deployment
 
 First, build your app for production:

--- a/docs/ACTIONS_NOTIFICATIONS.md
+++ b/docs/ACTIONS_NOTIFICATIONS.md
@@ -1,0 +1,30 @@
+# GitHub Actions Failure Notifications
+
+This repo sends Slack and Telegram notifications when the Playwright workflow
+fails.
+
+## Current Scope
+
+- Workflow: `Playwright E2E Tests`
+- Job watched: `test` matrix across Chromium, Firefox, and WebKit
+- Notify on: failed matrix result only
+- Do not notify on: cancelled or successful runs
+
+## Required GitHub Secrets
+
+Add these as repository secrets, or organization secrets scoped to this repo:
+
+| Secret | Required for | Notes |
+| --- | --- | --- |
+| `SLACK_WEBHOOK_URL` | Slack | Incoming webhook URL for the target Slack channel. |
+| `TELEGRAM_BOT_TOKEN` | Telegram | Bot token from BotFather or the Hermes Telegram bot. |
+| `TELEGRAM_CHAT_ID` | Telegram | Target user, group, or channel chat ID. |
+
+Missing notification secrets do not fail the workflow. The notification job
+prints a skip message for the missing channel and continues.
+
+## Message Contents
+
+Each alert includes the repository, workflow, watched job, branch/ref, short
+commit SHA, actor, triggering event, run number, and a link to the failed run.
+Telegram uses HTML formatting with escaped dynamic values.


### PR DESCRIPTION
## Summary
- add reusable Slack/Telegram failure notification workflow
- notify once when the Playwright matrix fails
- document required notification secrets and message contents

## Tested
- go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/*.yml
- git diff --check
- gitnexus detect_changes reported low risk / no affected processes